### PR TITLE
update to remote-sdk-go v0.2.0

### DIFF
--- a/cmd/nop/main.go
+++ b/cmd/nop/main.go
@@ -1,3 +1,6 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
 package main
 
 import "github.com/titan-data/remote-sdk-go/remote"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/titan-data/nop-remote-go
 
 require (
 	github.com/stretchr/testify v1.4.0
-	github.com/titan-data/remote-sdk-go v0.1.0
+	github.com/titan-data/remote-sdk-go v0.2.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.10.1 h1:uyt/l0dWjJ879yiAu+T7FG3/6QX+zwm4bQ8P7XsYt3o=
 github.com/hashicorp/go-hclog v0.10.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v0.11.0 h1:zf3QG3ap4KOMHzDLxBvq9ZtEFVSxQzVdH1ccl5NK2tU=
+github.com/hashicorp/go-hclog v0.11.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cRWgnE=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
@@ -48,6 +50,8 @@ github.com/titan-data/remote-sdk-go v0.0.3 h1:kGLc7JP7znTcXyl3gRML2jEST99ebdhz0C
 github.com/titan-data/remote-sdk-go v0.0.3/go.mod h1:b4McaOFiLYWv2/wCQW/sE2BcCSNz/Ae6iKKEtqw703w=
 github.com/titan-data/remote-sdk-go v0.1.0 h1:Xab4sduqyGdo04eJ5mQ2lIfAYZDjHJ4AzlK4oJ5EqqE=
 github.com/titan-data/remote-sdk-go v0.1.0/go.mod h1:u7w3Olu3EtjoFcHzxUOzelxedey4q2nveuKLvgRO7tg=
+github.com/titan-data/remote-sdk-go v0.2.0 h1:fkw/4AqY8XAnhh6h/u1SUvv5eIoPIVAabLhMahjpuLo=
+github.com/titan-data/remote-sdk-go v0.2.0/go.mod h1:IYCrMWL1hFGoYusrTHgseG/bLVuY72LpQSSdGOrcHb4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/nop/nop.go
+++ b/nop/nop.go
@@ -19,13 +19,13 @@ func (n nopRemote) Type() (string, error) {
 }
 
 func (n nopRemote) FromURL(rawUrl string, properties map[string]string) (map[string]interface{}, error) {
-	url, err := url.Parse(rawUrl)
+	u, err := url.Parse(rawUrl)
 	if err != nil {
 		return nil, err
 	}
 
 	// nop remotes can only be "nop", which means everything other than "path" must be empty
-	if url.Scheme != "" || url.Host != "" || url.User != nil || url.Path != "nop" {
+	if u.Scheme != "" || u.Host != "" || u.User != nil || u.Path != "nop" {
 		return nil, errors.New("malformed remote")
 	}
 
@@ -36,12 +36,39 @@ func (n nopRemote) FromURL(rawUrl string, properties map[string]string) (map[str
 	return map[string]interface{}{}, nil
 }
 
-func (n nopRemote) ToURL(properties map[string]interface{}) (string, map[string]string, error) {
+func (n nopRemote) ToURL(_ map[string]interface{}) (string, map[string]string, error) {
 	return "nop", map[string]string{}, nil
 }
 
-func (n nopRemote) GetParameters(properties map[string]interface{}) (map[string]interface{}, error) {
+func (n nopRemote) GetParameters(_ map[string]interface{}) (map[string]interface{}, error) {
 	return map[string]interface{}{}, nil
+}
+
+func (n nopRemote) ValidateRemote(properties map[string]interface{}) error {
+	for k := range properties {
+		return fmt.Errorf("invalid remote property '%s'", k)
+	}
+	return nil
+}
+
+func (n nopRemote) ValidateParameters(parameters map[string]interface{}) error {
+	for k := range parameters {
+		if k != "delay" {
+			return fmt.Errorf("invalid parameters property '%s'", k)
+		}
+	}
+	return nil
+}
+
+func (n nopRemote) ListCommits(_ map[string]interface{}, _ map[string]interface{}, _ []remote.Tag) ([]remote.Commit, error) {
+	return []remote.Commit{}, nil
+}
+
+func (n nopRemote) GetCommit(_ map[string]interface{}, _ map[string]interface{}, commitId string) (*remote.Commit, error) {
+	return &remote.Commit{
+		Id:         commitId,
+		Properties: map[string]interface{}{},
+	}, nil
 }
 
 func init() {

--- a/nop/nop_test.go
+++ b/nop/nop_test.go
@@ -1,3 +1,6 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
 package nop
 
 import (
@@ -14,32 +17,85 @@ func TestRegistered(t *testing.T) {
 
 func TestFromURL(t *testing.T) {
 	r := remote.Get("nop")
-	props, err := r.FromURL("nop", map[string]string{})
-	assert.Equal(t, 0, len(props))
-	assert.Nil(t, err)
+	res, err := r.FromURL("nop", map[string]string{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, 0, len(res))
+		assert.Nil(t, err)
+	}
+}
+
+func TestBadUrl(t *testing.T) {
+	r := remote.Get("nop")
+	_, err := r.FromURL("not\nurl", map[string]string{})
+	assert.Error(t, err)
 }
 
 func TestBadAuthority(t *testing.T) {
 	r := remote.Get("nop")
 	_, err := r.FromURL("nop://foo", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadProperty(t *testing.T) {
 	r := remote.Get("nop")
 	_, err := r.FromURL("nop", map[string]string{"a": "b"})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestToURL(t *testing.T) {
 	r := remote.Get("nop")
-	u, props, _ := r.ToURL(map[string]interface{}{})
-	assert.Equal(t, "nop", u)
-	assert.Empty(t, props)
+	u, props, err := r.ToURL(map[string]interface{}{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "nop", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestGetParameters(t *testing.T) {
 	r := remote.Get("nop")
-	params, _ := r.GetParameters(map[string]interface{}{})
-	assert.Empty(t, params)
+	res, err := r.GetParameters(map[string]interface{}{})
+	if assert.NoError(t, err) {
+		assert.Empty(t, res)
+	}
+}
+
+func TestValidateRemoteSuccess(t *testing.T) {
+	r := remote.Get("nop")
+	err := r.ValidateRemote(map[string]interface{}{})
+	assert.NoError(t, err)
+}
+
+func TestValidateRemoteFailure(t *testing.T) {
+	r := remote.Get("nop")
+	err := r.ValidateRemote(map[string]interface{}{"a": "b"})
+	assert.Error(t, err)
+}
+
+func TestValidateParametersSuccess(t *testing.T) {
+	r := remote.Get("nop")
+	err := r.ValidateParameters(map[string]interface{}{})
+	assert.NoError(t, err)
+}
+
+func TestValidateParametersFailure(t *testing.T) {
+	r := remote.Get("nop")
+	err := r.ValidateParameters(map[string]interface{}{"a": "b"})
+	assert.Error(t, err)
+}
+
+func TestListCommits(t *testing.T) {
+	r := remote.Get("nop")
+	res, err := r.ListCommits(map[string]interface{}{}, map[string]interface{}{}, []remote.Tag{})
+	if assert.NoError(t, err) {
+		assert.Len(t, res, 0)
+	}
+}
+
+func TestGetCommit(t *testing.T) {
+	r := remote.Get("nop")
+	res, err := r.GetCommit(map[string]interface{}{}, map[string]interface{}{}, "id")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "id", res.Id)
+		assert.Len(t, res.Properties, 0)
+	}
 }


### PR DESCRIPTION
## Proposed Changes

Updates to v0.2.0 and ports the corresponding server interfaces from kotlin. Also fixed the code to be more idiomatic go / testify now that I know more.

## Testing

`go test ./...` and verify 100% coverage.